### PR TITLE
Update all requirements

### DIFF
--- a/chapter3/complete/requirements.txt
+++ b/chapter3/complete/requirements.txt
@@ -1,2 +1,4 @@
-SQLAlchemy>=2.0.0,<2.1.0
-Pytest>=8.1.0,<8.2.0
+#Last tested versions
+#Successfully installed Pytest-8.3.3 SQLAlchemy-2.0.36 greenlet-3.1.1 iniconfig-2.0.0 pluggy-1.5.0
+SQLAlchemy>=2.0.0
+Pytest>=8.1.0

--- a/chapter4/complete/requirements.txt
+++ b/chapter4/complete/requirements.txt
@@ -1,7 +1,8 @@
-#Chapter 4 pip requirements
-SQLAlchemy>=2.0.0,<2.1.0
-pydantic>=2.4.0,<2.5.0
-fastapi[standard]>=0.115.0,<0.116.0
-uvicorn>=0.23.0,<0.24.0
-Pytest>=8.1.0,<8.2.0
-httpx>=0.27.0,<0.28.0
+#Last tested versions
+#Successfully installed annotated-types-0.7.0 click-8.1.7 dnspython-2.7.0 email-validator-2.2.0 fastapi-0.115.4 fastapi-cli-0.0.5 httptools-0.6.4 markdown-it-py-3.0.0 mdurl-0.1.2 pydantic-2.9.2 pydantic-core-2.23.4 python-dotenv-1.0.1 python-multipart-0.0.17 rich-13.9.4 shellingham-1.5.4 starlette-0.41.2 typer-0.12.5 uvicorn-0.32.0 uvloop-0.21.0 watchfiles-0.24.0 websockets-13.1
+SQLAlchemy>=2.0.0
+pydantic>=2.4.0
+fastapi[standard]>=0.115.0
+uvicorn>=0.23.0
+Pytest>=8.1.0
+httpx>=0.27.0

--- a/chapter5/complete/requirements.txt
+++ b/chapter5/complete/requirements.txt
@@ -1,7 +1,8 @@
-#Chapter 4 pip requirements
-SQLAlchemy>=2.0.0,<2.1.0
-pydantic>=2.4.0,<2.5.0
-fastapi[standard]>=0.115.0,<0.116.0
-uvicorn>=0.23.0,<0.24.0
-Pytest>=8.1.0,<8.2.0
-httpx>=0.27.0,<0.28.0
+#Last tested versions
+#Successfully installed annotated-types-0.7.0 click-8.1.7 dnspython-2.7.0 email-validator-2.2.0 fastapi-0.115.4 fastapi-cli-0.0.5 httptools-0.6.4 markdown-it-py-3.0.0 mdurl-0.1.2 pydantic-2.9.2 pydantic-core-2.23.4 python-dotenv-1.0.1 python-multipart-0.0.17 rich-13.9.4 shellingham-1.5.4 starlette-0.41.2 typer-0.12.5 uvicorn-0.32.0 uvloop-0.21.0 watchfiles-0.24.0 websockets-13.1
+SQLAlchemy>=2.0.0
+pydantic>=2.4.0
+fastapi[standard]>=0.115.0
+uvicorn>=0.23.0
+Pytest>=8.1.0
+httpx>=0.27.0

--- a/chapter6/complete/requirements.txt
+++ b/chapter6/complete/requirements.txt
@@ -1,6 +1,8 @@
-SQLAlchemy>=2.0.0,<2.1.0
-pydantic>=2.4.0,<2.5.0
-fastapi[standard]>=0.115.0,<0.116.0
-uvicorn>=0.23.0,<0.24.0
-Pytest>=8.1.0,<8.2.0
-httpx>=0.27.0,<0.28.0
+#Last tested versions
+#Successfully installed annotated-types-0.7.0 click-8.1.7 dnspython-2.7.0 email-validator-2.2.0 fastapi-0.115.4 fastapi-cli-0.0.5 httptools-0.6.4 markdown-it-py-3.0.0 mdurl-0.1.2 pydantic-2.9.2 pydantic-core-2.23.4 python-dotenv-1.0.1 python-multipart-0.0.17 rich-13.9.4 shellingham-1.5.4 starlette-0.41.2 typer-0.12.5 uvicorn-0.32.0 uvloop-0.21.0 watchfiles-0.24.0 websockets-13.1
+SQLAlchemy>=2.0.0
+pydantic>=2.4.0
+fastapi[standard]>=0.115.0
+uvicorn>=0.23.0
+Pytest>=8.1.0
+httpx>=0.27.0

--- a/chapter7/complete/sdk/tests/test_swcpy.py
+++ b/chapter7/complete/sdk/tests/test_swcpy.py
@@ -8,6 +8,9 @@ import pandas as pd
 import csv
 import os
 from io import StringIO
+from dotenv import load_dotenv
+
+
 
 current_dir = os.path.dirname(__file__)
 data_dir = current_dir + "/test_data_output/"
@@ -26,22 +29,24 @@ Typical usage example:
 
 """
 
-
-config = SWCConfig(url="http://0.0.0.0:8000",backoff=False)
+config = SWCConfig(backoff=False)
 client = SWCClient(config)    
+
+def test_environment_variable():
+    import os
+
+    # Retrieve the environment variable
+    swc_base_url = os.getenv('SWC_API_BASE_URL')
+
+    # Print the value of the environment variable
+    print(f"API_BASE_URL: {swc_base_url}")
+    # Check if the environment variable is set correctly
+    assert(swc_base_url == 'http://0.0.0.0:8000')
 
 
 def test_health_check():
     """Tests health check from SDK"""
-    config = SWCConfig(url="http://0.0.0.0:8000",backoff=False)
-    client = SWCClient(config)    
-    response = client.get_health_check()
-    assert response.status_code == 200
-    assert response.json() == {"message": "API health check successful"}
-
-def test_health_check_with_URL():
-    """Tests health check from SDK"""
-    config = SWCConfig(url="http://0.0.0.0:8000")
+    config = SWCConfig(backoff=False)
     client = SWCClient(config)    
     response = client.get_health_check()
     assert response.status_code == 200
@@ -49,7 +54,7 @@ def test_health_check_with_URL():
 
 def test_list_leagues():
     """Tests get leagues from SDK"""
-    config = SWCConfig(url="http://0.0.0.0:8000",backoff=False)
+    config = SWCConfig(backoff=False)
     client = SWCClient(config)    
     leagues_response = client.list_leagues()
     # Assert the endpoint returned a list object
@@ -62,7 +67,6 @@ def test_list_leagues():
 
 def test_list_leagues_no_backoff():
     """Tests get leagues from SDK without backoff"""
-    config = SWCConfig(url="http://0.0.0.0:8000",backoff=False)
     client = SWCClient(config)    
     leagues_response = client.list_leagues()
     # Assert the list is not empty


### PR DESCRIPTION
Instead of using maximum version, only have minimum.

This resolves dependabot alerts so that the versions are forcing an old version.

However, future versions may break the code, so I have included a comment in the requirements that shows the versions that have been tested.